### PR TITLE
License Section

### DIFF
--- a/Develop/utils/generateMarkdown.js
+++ b/Develop/utils/generateMarkdown.js
@@ -32,7 +32,14 @@ function renderLicenseLink(license) {
 
 // TODO: Create a function that returns the license section of README
 // If there is no license, return an empty string
-function renderLicenseSection(license) {}
+function renderLicenseSection(license) {
+    if (license === 'None') {
+        return '';
+    } else {
+        return `## License
+        This project is licensed under the ${license} license.`
+    }
+}
 
 // TODO: Create a function to generate markdown for README
 function generateMarkdown(data) {


### PR DESCRIPTION
Create a function to include a license section in the README generator and an empty string if no license is chosen